### PR TITLE
Vulnerability: Users can authenticate as any user

### DIFF
--- a/src/pages/login/index.ts
+++ b/src/pages/login/index.ts
@@ -66,12 +66,5 @@ export async function POST(context: APIContext): Promise<Response> {
 		sameSite: "lax",
 		secure: !import.meta.env.DEV,
 	});
-	context.cookies.set("did", did, {
-		httpOnly: true,
-		path: "/",
-		maxAge: 60 * 10,
-		sameSite: "lax",
-		secure: !import.meta.env.DEV,
-	});
 	return new Response(authorizationURL.toString());
 }


### PR DESCRIPTION
Fixes a major vulnerability where one could authenticate as any user.

## Vulnerability

The app did not check if the authorization server was listed in the user's DID document in the OAuth callback step. A malicious actor could set up their own authorization server with a token endpoint that returned the DID of the user to impersonate.

## Fix

Compare the authorization server issuer against the one listed by the user's DID document after validating the authorization code.

## Why did this happen?

In a typical OAuth flow, the authorization server can be implicitly trusted. This is not the case when users can use their own servers and it was an embarrassing oversight on my end.
